### PR TITLE
Added color temp for RGB Lights and changed effects names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To set this system up, you need to configure the [MQTT JSON light](https://home-
         command_topic: "home/json_brightness/set"
         brightness: true
         effect: true
-        effect_list: [flash]
+        effect_list: ["Flash"]
         optimistic: false
         qos: 0
 
@@ -48,7 +48,7 @@ To set this system up, you need to configure the [MQTT JSON light](https://home-
         color_temp: true
         rgb: true
         effect: true
-        effect_list: [colorfade_slow, colorfade_fast, flash]
+        effect_list: ["ColorFade Slow", "ColorFade Fast", "Flash"]
         optimistic: false
         qos: 0
 
@@ -62,7 +62,7 @@ To set this system up, you need to configure the [MQTT JSON light](https://home-
         rgb: true
         white_value: true
         effect: true
-        effect_list: [colorfade_slow, colorfade_fast, flash]
+        effect_list: ["ColorFade Slow", "ColorFade Fast", "Flash"]
         optimistic: false
         qos: 0
     ```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ To set this system up, you need to configure the [MQTT JSON light](https://home-
         state_topic: "home/rgb1"
         command_topic: "home/rgb1/set"
         brightness: true
+        color_temp: true
         rgb: true
         effect: true
         effect_list: [colorfade_slow, colorfade_fast, flash]

--- a/mqtt_esp8266_brightness/mqtt_esp8266_brightness.ino
+++ b/mqtt_esp8266_brightness/mqtt_esp8266_brightness.ino
@@ -181,7 +181,7 @@ bool processJson(char* message) {
 
   // If "flash" is included, treat RGB and brightness differently
   if (root.containsKey("flash") ||
-       (root.containsKey("effect") && strcmp(root["effect"], "flash") == 0)) {
+       (root.containsKey("effect") && strcmp(root["effect"], "Flash") == 0)) {
 
     if (root.containsKey("flash")) {
       flashLength = (int)root["flash"] * 1000;

--- a/mqtt_esp8266_rgb/mqtt_esp8266_rgb.ino
+++ b/mqtt_esp8266_rgb/mqtt_esp8266_rgb.ino
@@ -162,7 +162,7 @@ void setup_wifi() {
       "flash": 2,
       "transition": 5,
       "state": "ON",
-      "effect": "colorfade_fast"
+      "effect": "ColorFade Fast"
     }
   */
 void callback(char* topic, byte* payload, unsigned int length) {
@@ -220,7 +220,7 @@ bool processJson(char* message) {
 
   // If "flash" is included, treat RGB and brightness differently
   if (root.containsKey("flash") ||
-       (root.containsKey("effect") && strcmp(root["effect"], "flash") == 0)) {
+       (root.containsKey("effect") && strcmp(root["effect"], "Flash") == 0)) {
 
     if (root.containsKey("flash")) {
       flashLength = (int)root["flash"] * 1000;
@@ -255,11 +255,11 @@ bool processJson(char* message) {
     startFlash = true;
   }
   else if (root.containsKey("effect") &&
-      (strcmp(root["effect"], "colorfade_slow") == 0 || strcmp(root["effect"], "colorfade_fast") == 0)) {
+      (strcmp(root["effect"], "ColorFade Slow") == 0 || strcmp(root["effect"], "ColorFade Fast") == 0)) {
     flash = false;
     colorfade = true;
     currentColor = 0;
-    if (strcmp(root["effect"], "colorfade_slow") == 0) {
+    if (strcmp(root["effect"], "ColorFade Slow") == 0) {
       transitionTime = CONFIG_COLORFADE_TIME_SLOW;
     }
     else {
@@ -322,10 +322,10 @@ void sendState() {
 
   if (colorfade) {
     if (transitionTime == CONFIG_COLORFADE_TIME_SLOW) {
-      root["effect"] = "colorfade_slow";
+      root["effect"] = "ColorFade Slow";
     }
     else {
-      root["effect"] = "colorfade_fast";
+      root["effect"] = "ColorFade Fast";
     }
   }
   else {

--- a/mqtt_esp8266_rgbw/mqtt_esp8266_rgbw.ino
+++ b/mqtt_esp8266_rgbw/mqtt_esp8266_rgbw.ino
@@ -151,7 +151,7 @@ void setup_wifi() {
       "flash": 2,
       "transition": 5,
       "state": "ON",
-      "effect": "colorfade_fast"
+      "effect": "ColorFade Fast"
     }
   */
 void callback(char* topic, byte* payload, unsigned int length) {
@@ -211,7 +211,7 @@ bool processJson(char* message) {
 
   // If "flash" is included, treat RGB and brightness differently
   if (root.containsKey("flash") ||
-       (root.containsKey("effect") && strcmp(root["effect"], "flash") == 0)) {
+       (root.containsKey("effect") && strcmp(root["effect"], "Flash") == 0)) {
 
     if (root.containsKey("flash")) {
       flashLength = (int)root["flash"] * 1000;
@@ -254,11 +254,11 @@ bool processJson(char* message) {
     startFlash = true;
   }
   else if (root.containsKey("effect") &&
-      (strcmp(root["effect"], "colorfade_slow") == 0 || strcmp(root["effect"], "colorfade_fast") == 0)) {
+      (strcmp(root["effect"], "ColorFade Slow") == 0 || strcmp(root["effect"], "ColorFade Fast") == 0)) {
     flash = false;
     colorfade = true;
     currentColor = 0;
-    if (strcmp(root["effect"], "colorfade_slow") == 0) {
+    if (strcmp(root["effect"], "ColorFade Slow") == 0) {
       transitionTime = CONFIG_COLORFADE_TIME_SLOW;
     }
     else {
@@ -316,10 +316,10 @@ void sendState() {
 
   if (colorfade) {
     if (transitionTime == CONFIG_COLORFADE_TIME_SLOW) {
-      root["effect"] = "colorfade_slow";
+      root["effect"] = "ColorFade Slow";
     }
     else {
-      root["effect"] = "colorfade_fast";
+      root["effect"] = "ColorFade Fast";
     }
   }
   else {


### PR DESCRIPTION
I added a new setting to allow a user to select a color temperature with RGB lights.
It makes it easier to choose the perfect white temperature, as it can now be selected on a separated slider in Home Assistant.

I also have changed the display names of effects for the three types of light to get a cleaner look in HA:
`effect_list: ["ColorFade Slow", "ColorFade Fast", "Flash"]`