### PR TITLE
Add support for custom input range

### DIFF
--- a/mqtt_esp8266_light/config-sample.h
+++ b/mqtt_esp8266_light/config-sample.h
@@ -14,6 +14,10 @@ enum strip {
 
 #define CONFIG_STRIP RGB // Choose one of the options from above.
 
+// If voltages below 150 cause the LED strip to switch off, then adjust the lower range here such tht the slider in Home Assistant has the desired effect
+#define MIN_RANGE 0
+#define MAX_RANGE 255
+
 // Pins
 // In case of BRIGHTNESS: only WHITE is used
 // In case of RGB(W): red, green, blue(, white) is used

--- a/mqtt_esp8266_light/mqtt_esp8266_light.ino
+++ b/mqtt_esp8266_light/mqtt_esp8266_light.ino
@@ -226,7 +226,7 @@ bool processJson(char* message) {
     }
 
     if (root.containsKey("brightness")) {
-      flashBrightness = root["brightness"];
+      flashBrightness = map(root["brightness"], 0, 255, MIN_RANGE, MAX_RANGE);
     }
     else {
       flashBrightness = brightness;
@@ -273,7 +273,7 @@ bool processJson(char* message) {
   else if (colorfade && !root.containsKey("color") && root.containsKey("brightness")) {
     // Adjust brightness during colorfade
     // (will be applied when fading to the next color)
-    brightness = root["brightness"];
+    brightness = map(root["brightness"], 0, 255, MIN_RANGE, MAX_RANGE);
   }
   else { // No effect
     flash = false;
@@ -290,7 +290,7 @@ bool processJson(char* message) {
     }
 
     if (root.containsKey("brightness")) {
-      brightness = root["brightness"];
+      brightness = map(root["brightness"], 0, 255, MIN_RANGE, MAX_RANGE);
     }
 
     if (root.containsKey("transition")) {
@@ -317,7 +317,7 @@ void sendState() {
     color["b"] = blue;
   }
 
-  root["brightness"] = brightness;
+  root["brightness"] = map(brightness, MIN_RANGE, MAX_RANGE, 0, 255);
 
   if (includeWhite) {
     root["white_value"] = white;


### PR DESCRIPTION
This tweak allows for a configurable brightness input range.
If the LED strip hardware does not support brightness values below 150 (because the LED strip cannot operate at that low a voltage), the user can specify a min and a max brightness value. 
The advantage of this is that the full range of values (0-255) can be used in Home Assistant, while internally it is converted to the requirements of the hardware (150-255).

Have applied this to brightness only because that is my use case. If this is a feature you want to merge let me know and we can discuss how to apply it to all RGB values.